### PR TITLE
Add PayPal CSV support

### DIFF
--- a/tiller_utils/institutions/paypal.py
+++ b/tiller_utils/institutions/paypal.py
@@ -1,0 +1,43 @@
+import polars as pl
+from datetime import datetime
+from tiller_utils.date_utils import utc_ts
+
+
+def convert_to_tiller(df):
+    """Convert a PayPal CSV to Tiller-friendly format"""
+    empty_columns = [
+        "Category", "Metadata", "Full Description", "Categorized Date", "Check Number",
+        "Month", "Week",
+    ]
+
+    df_tiller = (
+        df
+        .filter(~pl.col("Type").is_in(["Bank Deposit to PP Account ", "General Authorization"]))
+        .with_columns(
+            pl.col("Date").alias("Date"),
+            pl.col("Name").alias("Description"),
+            pl.col("Amount").cast(pl.Float64).alias("Amount"),
+            pl.lit("PayPal").alias("Account #"),
+        )
+        .with_row_index()
+        .with_columns(
+            (pl.lit(f"manual:{utc_ts()}--") + pl.col("index").cast(pl.String)).alias("Transaction ID")
+        )
+        .drop("index")
+        .with_columns(
+            pl.lit("PayPal").alias("Institution"),
+            pl.lit("PayPal").alias("Account"),
+            pl.lit("PayPal").alias("Account ID"),
+            pl.lit(datetime.today()).alias("Date Added"),
+        )
+        .with_columns(
+            *[pl.lit(None).alias(col) for col in empty_columns]
+        )
+        .drop(["Time", "TimeZone", "Type", "Status", "Currency", "Receipt ID", "Balance", "Name"])
+        .select(
+            "Date", "Description", "Category", "Amount", "Account", "Account #",
+            "Institution", "Month", "Week", "Transaction ID", "Account ID", "Check Number",
+            "Full Description", "Date Added", "Metadata",
+        )
+    )
+    return df_tiller

--- a/tiller_utils/institutions/paypal.py
+++ b/tiller_utils/institutions/paypal.py
@@ -16,7 +16,7 @@ def convert_to_tiller(df):
         .with_columns(
             pl.col("Date").alias("Date"),
             pl.col("Name").alias("Description"),
-            pl.col("Amount").cast(pl.Float64).alias("Amount"),
+            pl.col("Amount").str.replace_all(",", "").cast(pl.Float64).alias("Amount"),
             pl.lit("PayPal").alias("Account #"),
         )
         .with_row_index()

--- a/tiller_utils/runner.py
+++ b/tiller_utils/runner.py
@@ -35,7 +35,11 @@ def main():
     csv_path = Path(kwargs["source_csv"])
     institution = kwargs.get("institution", "capitalone").lower()
 
-    raw_df = pl.read_csv(csv_path)
+    read_kwargs = {}
+    if institution == "paypal":
+        read_kwargs["dtypes"] = {"Amount": pl.Utf8, "Balance": pl.Utf8}
+
+    raw_df = pl.read_csv(csv_path, **read_kwargs)
 
     if institution == "capitalone":
         new_df = co_convert_to_tiller(raw_df)

--- a/tiller_utils/runner.py
+++ b/tiller_utils/runner.py
@@ -1,7 +1,8 @@
 import argparse
 import polars as pl
 from pathlib import Path
-from tiller_utils.institutions.capitalone import convert_to_tiller, agg_amount_type
+from tiller_utils.institutions.capitalone import convert_to_tiller as co_convert_to_tiller, agg_amount_type
+from tiller_utils.institutions.paypal import convert_to_tiller as paypal_convert_to_tiller
 from tiller_utils.date_utils import utc_ts
 
 def bake_options():
@@ -31,21 +32,28 @@ def get_args():
 def main():
     kwargs = get_args()
 
-    capital_one_csv_path = Path(kwargs["source_csv"])
-    capital_one_raw_df = convert_to_tiller(
-        pl.read_csv( capital_one_csv_path )
-    ).drop_nulls()
+    csv_path = Path(kwargs["source_csv"])
+    institution = kwargs.get("institution", "capitalone").lower()
 
-    new_path = capital_one_csv_path.with_stem(
+    raw_df = pl.read_csv(csv_path)
+
+    if institution == "capitalone":
+        new_df = co_convert_to_tiller(raw_df)
+    elif institution == "paypal":
+        new_df = paypal_convert_to_tiller(raw_df)
+    else:
+        raise ValueError(f"Unsupported institution: {institution}")
+
+    new_df = new_df.drop_nulls()
+
+    new_path = csv_path.with_stem(
         utc_ts()
-        + "-" 
-        + capital_one_csv_path.stem
+        + "-"
+        + csv_path.stem
         + "--for-tiller"
     )
 
-    (capital_one_raw_df
- .write_csv((new_path))
-)
+    new_df.write_csv(new_path)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- implement PayPal CSV converter
- update runner to choose converter by institution argument

## Testing
- `python -m compileall -q tiller_utils`

------
https://chatgpt.com/codex/tasks/task_e_6861859beeb08333a4658edbd2d0e971